### PR TITLE
 Switch from lncli to the gRPC API

### DIFF
--- a/rebalance.py
+++ b/rebalance.py
@@ -10,7 +10,7 @@ import sys
 import rpc_pb2 as ln, rpc_pb2_grpc as lnrpc
 
 HIGH_FEES_THRESHOLD_MSAT = 3000000
-LND_DIR = "/home/wamde/.lnd/"
+LND_DIR = "/PATH/TO/LND/DIR"
 macaroon = codecs.encode(open(LND_DIR + 'data/chain/bitcoin/mainnet/admin.macaroon', 'rb').read(), 'hex')
 os.environ['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA'
 cert = open(LND_DIR + 'tls.cert', 'rb').read()


### PR DESCRIPTION
Switched to gRPC to interface with lnd.
All changes from lncli to the gRPC API are straightforward and mostly consist in dealing with protos rather than JSON-formatted data. One exception is the generate_invoice function, especially where the formatting of r_hash is confusing to be later used in LookupInvoice. The workaround implemented is to take the payment_request and then DecodePayReq which gives a payment_hash.
This PR requires having the pre-compiled proto files for the RPC service, as described in the dev guides (https://dev.lightning.community/guides/python-grpc/)