### PR TITLE
More incoming and outgoing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ usage: rebalance.py [-h] [-d] [-l] [-o] [-i] [-f FROMCHAN] [-t TOCHAN]
                     [amount]
 
 positional arguments:
-  amount                Amount or the rebalance, in satoshis. If not
+  amount                Amount of the rebalance, in satoshis. If not
                         specified, the amount computed for a perfect rebalance
                         will be used
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,31 @@ $ pip install grpcio googleapis-common-protos
 
 ## Usage
 
+### Command line arguments
+```
+usage: rebalance.py [-h] [-d] [-l] [-o] [-i] [-f FROMCHAN] [-t TOCHAN]
+                    [amount]
+
+positional arguments:
+  amount                Amount or the rebalance, in satoshis. If not
+                        specified, the amount computed for a perfect rebalance
+                        will be used
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -d, --debug           Verbose debug mode
+  -l, --listcandidates  List candidate channels for rebalance.Use in
+                        conjunction with -o and -i
+  -o, --outgoing        When used with -l, lists candidate outgoing channels
+  -i, --incoming        When used with -l, lists candidate incoming channels
+  -f FROMCHAN, --fromchan FROMCHAN
+                        Channel id for the outgoing channel (which will be
+                        emptied)
+  -t TOCHAN, --tochan TOCHAN
+                        Channel id for the incoming channel (which will be
+                        filled)
+```
+
 ### List of channels
 Run `./rebalance.py` without any arguments to see a list of channels which can be rebalanced.
 This list only contains channels where less than 50% of the total funds are on the local side of the channel.
@@ -25,19 +50,19 @@ As an example the following indicates a channel with around 17.7% of the funds o
 
 ```
 (23) Pubkey:      012345[...]abcdef
-Local ratio:      0.17689625535
-Capacity:         5000000
-Remote balance:   4110320
-Local balance:    883364
-Amount for 50-50: 1613478
+Local ratio:      0.176
+Capacity:         5,000,000
+Remote balance:   4,110,320
+Local balance:    883,364
+Amount for 50-50: 1,613,478
 |=====                       |
 ```
 
-By sending 1613478 satoshis to yourself using this channel, a ratio of 50% can be achieved.
+By sending 1,613,478 satoshis to yourself using this channel, a ratio of 50% can be achieved.
 This number is shown as "Amount for 50-50".
 
 The last line shows a graphical representation of the channel. 
-The total width is determined by the channel's capacity, where a channel with maximum capacity (16777215 satoshis)
+The total width is determined by the channel's capacity, where a channel with maximum capacity (16,777,215 satoshis)
 occupies the full width of your terminal.
 The bar (`=`) indicates the funds on the local side of the channel.
 
@@ -61,6 +86,8 @@ The maximum amount you can send in one transaction currently is limited (by the 
 Contributions are highly welcome!
 Feel free to submit issues and pull requests on https://github.com/C-Otto/rebalance-lnd/
 
-Please also consider opening a channel with my node:
+Please also consider opening a channel with one of our nodes:
 
-027ce055380348d7812d2ae7745701c9f93e70c1adeb2657f053f91df4f2843c71@137.226.34.46:9735
+C-Otto: `027ce055380348d7812d2ae7745701c9f93e70c1adeb2657f053f91df4f2843c71@137.226.34.46:9735`
+
+wamde: `0269b91661812bae52280a68eec2b89d38bf26b33966441ad70aa365e120a125ff@82.36.141.97:9735`

--- a/logic.py
+++ b/logic.py
@@ -7,17 +7,20 @@ def debug(message):
 
 
 class Logic:
-    def __init__(self, lnd, remote_pubkey, amount):
+    def __init__(self, lnd, first_hop_pubkey, remote_pubkey, amount):
         self.lnd = lnd
+        self.first_hop_pubkey = first_hop_pubkey
         self.remote_pubkey = remote_pubkey
         self.amount = amount
 
     def rebalance(self):
         debug("Sending %d satoshis to rebalance, remote pubkey: %s" %
               (self.amount, self.remote_pubkey))
+        if self.first_hop_pubkey:
+            debug("Forced first pubkey is: %s" % self.first_hop_pubkey)
 
         payment_request = self.generate_invoice()
-        routes = Routes(self.lnd, payment_request, self.remote_pubkey)
+        routes = Routes(self.lnd, payment_request, self.first_hop_pubkey, self.remote_pubkey)
 
         if not routes.has_next():
             debug("Could not find any suitable route")

--- a/rebalance.py
+++ b/rebalance.py
@@ -23,7 +23,7 @@ def main():
     parser.add_argument("channel", help=("channel identifier, can be either the channel index as given by -l"
                                          " or the channel's pubkey"), nargs="?")
     # args.amount is essentially a list, and what matters to us is the first value it *may* have
-    parser.add_argument("amount", help=("amount or the rebalance, in satoshis. If not specified, the amount computed"
+    parser.add_argument("amount", help=("amount of the rebalance, in satoshis. If not specified, the amount computed"
                                         " for a perfect rebalance will be used"), nargs='?')
     args = parser.parse_args()
 

--- a/rebalance.py
+++ b/rebalance.py
@@ -27,7 +27,7 @@ def main():
     parser.add_argument("-f", "--fromchan", help="Channel id for the outgoing channel (which will be emptied)")
     parser.add_argument("-t", "--tochan", help="Channel id for the incoming channel (which will be filled)")
     # args.amount is essentially a list, and what matters to us is the first value it *may* have
-    parser.add_argument("amount", help=("Amount or the rebalance, in satoshis. If not specified, the amount computed"
+    parser.add_argument("amount", help=("Amount of the rebalance, in satoshis. If not specified, the amount computed"
                                         " for a perfect rebalance will be used"), nargs="?")
     args = parser.parse_args()
 

--- a/rebalance.py
+++ b/rebalance.py
@@ -23,7 +23,7 @@ def main():
     parser.add_argument("channel", help=("channel identifier, can be either the channel index as given by -l"
                                          " or the channel's pubkey"), nargs="?")
     # args.amount is essentially a list, and what matters to us is the first value it *may* have
-    parser.add_argument("amount", help=("amount of the rebalance, in satoshis. If not specified, the amount computed"
+    parser.add_argument("amount", help=("amount or the rebalance, in satoshis. If not specified, the amount computed"
                                         " for a perfect rebalance will be used"), nargs='?')
     args = parser.parse_args()
 
@@ -41,6 +41,9 @@ def main():
     else:
         # else the channel argument should be the node's pubkey
         remote_pubkey = args.channel
+        # candidate is a channel -- we find it by filtering through all candidates
+        # TODO: add protection for when that pubkey is not found etc
+        candidate = [c for c in get_rebalance_candidates() if c.remote_pubkey == remote_pubkey][0]
 
     # then we figure out whether an amount was specified or if we compute it ourselves
     if args.amount:

--- a/rebalance.py
+++ b/rebalance.py
@@ -14,31 +14,62 @@ MAX_SATOSHIS_PER_TRANSACTION = 4294967
 
 
 def main():
+    remote_pubkey = None
+    amount = None
+
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-l", "--listcandidates", action="store_true", default=False)
-    parser.add_argument("channel", help=("channel identifier, can be either the channel index as given by -l"
-                                         " or the channel's pubkey"), nargs="?")
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="Verbose debug mode")
+    parser.add_argument("-l", "--listcandidates", action="store_true", default=False, help=("List candidate channels for rebalance."
+                                                                                            "Use in conjunction with -o and -i"))
+    parser.add_argument("-o", "--outgoing", action="store_true", help="When used with -l, lists candidate outgoing channels")
+    parser.add_argument("-i", "--incoming", action="store_true", help="When used with -l, lists candidate incoming channels")
+    parser.add_argument("-f", "--fromchan", help="Channel id for the outgoing channel (which will be emptied)")
+    parser.add_argument("-t", "--tochan", help="Channel id for the incoming channel (which will be filled)")
     # args.amount is essentially a list, and what matters to us is the first value it *may* have
-    parser.add_argument("amount", help=("amount of the rebalance, in satoshis. If not specified, the amount computed"
-                                        " for a perfect rebalance will be used"), nargs='?')
+    parser.add_argument("amount", help=("Amount or the rebalance, in satoshis. If not specified, the amount computed"
+                                        " for a perfect rebalance will be used"), nargs="?")
     args = parser.parse_args()
 
-    if args.listcandidates or args.channel is None:
-        list_candidates()
+    debug = args.debug
+
+    if debug:
+        print "from: %s\nto: %s\namount: %s" % (args.fromchan, args.tochan, args.amount)
+        print "outgoing: %s\nincoming: %s" % (args.outgoing, args.incoming)
+
+    if (args.outgoing or args.incoming) and not args.listcandidates:
+        print "--outgoing and --incoming only work in conjunction with --listcandidates"
+        sys.exit()
+
+    if args.listcandidates or (args.fromchan is None and args.tochan is None):
+        if (args.outgoing and args.incoming):
+            print "Only one of outgoing and incoming supported at once, defaulting to incoming."
+            incoming = True
+        else:
+            incoming = not args.outgoing
+        list_candidates(incoming=incoming)
+        sys.exit()
+
+    # If only the outgoing channel is specified, we need to find routes to any inbound channel, so there
+    # is some work to do to find all channels with incoming capacity, find routes to them, rank them etc. We could
+    # also think of splitting the amount to distribute it over several incoming channels to keep them at reasonable 
+    # levels. Anyway, not supported yet.
+    if args.fromchan and (args.tochan is None):
+        print "Outgoing-only mode is not supported yet."
         sys.exit()
 
     # first we deal with the first argument, channel, to figure out what it means
-    if args.channel and len(args.channel) < 4:
+    if args.tochan and len(args.tochan) < 4:
         # here we are in the "channel index" case
-        index = int(args.channel) - 1
+        index = int(args.tochan) - 1
         candidates = get_rebalance_candidates()
         candidate = candidates[index]
         remote_pubkey = candidate.remote_pubkey
     else:
         # else the channel argument should be the node's pubkey
-        remote_pubkey = args.channel
+        remote_pubkey = args.tochan
         # candidate is a channel -- we find it by filtering through all candidates
+        # TODO: add protection for when that pubkey is not found etc
         candidate = [c for c in get_rebalance_candidates() if c.remote_pubkey == remote_pubkey][0]
 
     # then we figure out whether an amount was specified or if we compute it ourselves
@@ -49,35 +80,43 @@ def main():
         if amount > MAX_SATOSHIS_PER_TRANSACTION:
             amount = MAX_SATOSHIS_PER_TRANSACTION
 
-    response = Logic(lnd, remote_pubkey, amount).rebalance()
+    # still dealing with pubkeys here, we need to switch to chan IDs eventually
+    first_hop_pubkey = args.fromchan
+    response = Logic(lnd, first_hop_pubkey, remote_pubkey, amount).rebalance()
     if response:
         print(response)
 
 
-def list_candidates():
+def list_candidates(incoming=True):
     index = 0
-    candidates = get_rebalance_candidates()
+    candidates = get_rebalance_candidates(incoming=incoming)
     for candidate in candidates:
         index += 1
-        rebalance_amount = int(math.ceil(float(get_remote_surplus(candidate)) / 2))
-        if rebalance_amount > MAX_SATOSHIS_PER_TRANSACTION:
-            rebalance_amount = str(rebalance_amount) + " (max per transaction: %d)" % MAX_SATOSHIS_PER_TRANSACTION
+        rebalance_amount_int = int(math.ceil(float(get_remote_surplus(candidate)) / 2))
+        rebalance_amount = "{:,}".format(rebalance_amount_int)
+        if rebalance_amount_int > MAX_SATOSHIS_PER_TRANSACTION:
+            rebalance_amount += " (max per transaction: {:,})".format(MAX_SATOSHIS_PER_TRANSACTION)
 
         print("(%2d) Pubkey:      " % index + candidate.remote_pubkey)
-        print("Local ratio:      " + str(get_local_ratio(candidate)))
-        print("Capacity:         " + str(candidate.capacity))
-        print("Remote balance:   " + str(candidate.remote_balance))
-        print("Local balance:    " + str(candidate.local_balance))
-        print("Amount for 50-50: " + str(rebalance_amount))
+        print("Local ratio:      {:.3f}".format(get_local_ratio(candidate)))
+        print("Capacity:         {:,}".format(candidate.capacity))
+        print("Remote balance:   {:,}".format(candidate.remote_balance))
+        print("Local balance:    {:,}".format(candidate.local_balance))
+        print("Amount for 50-50: " + rebalance_amount)
         print(get_capacity_and_ratio_bar(candidate))
         print("")
     print("")
     print("Run with two arguments: 1) pubkey of channel to fill 2) amount")
 
 
-def get_rebalance_candidates():
-    low_local = list(filter(lambda c: get_local_ratio(c) < 0.5, lnd.get_channels()))
-    return sorted(low_local, key=get_remote_surplus, reverse=False)
+def get_rebalance_candidates(incoming=True):
+    print "get_rebalance_candidates: incoming=%s" % incoming
+    if incoming:
+        low_local = list(filter(lambda c: get_local_ratio(c) < 0.5, lnd.get_channels()))
+        return sorted(low_local, key=get_remote_surplus, reverse=False)
+    else:
+        high_local = list(filter(lambda c: get_local_ratio(c) > 0.5, lnd.get_channels()))
+        return sorted(high_local, key=get_remote_surplus, reverse=True)  
 
 
 def get_local_ratio(channel):

--- a/routes.py
+++ b/routes.py
@@ -11,9 +11,10 @@ def debug(message):
 
 
 class Routes:
-    def __init__(self, lnd, payment_request, remote_pubkey):
+    def __init__(self, lnd, payment_request, first_hop_pubkey, remote_pubkey):
         self.lnd = lnd
         self.payment = payment_request
+        self.first_hop_pubkey = first_hop_pubkey
         self.remote_pubkey = remote_pubkey
         self.rebalance_channel = self.get_channel(self.remote_pubkey)
         self.all_routes = []
@@ -50,6 +51,9 @@ class Routes:
         self.num_requested_routes = num_routes_to_request
         result = []
         for route in routes:
+            if self.first_hop_pubkey and (route.hops[0].pub_key != self.first_hop_pubkey):
+                debug("Dropping route with %s as first hop (does not match -f)" % route.hops[0].pub_key)
+                continue
             modified_route = self.add_rebalance_channel(route)
             if modified_route:
                 result.append(modified_route)


### PR DESCRIPTION
- Added -f and -t flags (for funding and receiving channels, still denominated by pubkeys though)
- Added -o and -i flags to list candidates mode (default is -i, to list channels in need of incoming funds). This helps identify what to use with the -f flag
- Added formatting of printed values
- Added debug flag with minimal support for it (we need a proper logging system, per module, with several handlers on `stdout` and file output etc)
- Added simple route display when trying them one by one
- Some README updates (args usage, my node details)

Notes:
- This implements #3 and sets the stage for #16.
- I tested `-lo` and `-li` modes, along with `-f` and `-t` on my node, successfully.
- `-f`-only mode is not supported yet (see error printed and comments in the code).