### PR TITLE
Use the correct channel policy to calculate fees and cltv expiries

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -116,27 +116,30 @@ class Routes:
 
     def update_amounts(self, hops):
         additional_fees = 0
+        dest_chan_id = self.rebalance_channel.chan_id
         for hop in reversed(hops):
             amount_to_forward_msat = hop.amt_to_forward_msat + additional_fees
             hop.amt_to_forward_msat = amount_to_forward_msat
             hop.amt_to_forward = amount_to_forward_msat / 1000
 
             fee_msat_before = hop.fee_msat
-            new_fee_msat = self.get_fee_msat(amount_to_forward_msat, hop.chan_id, hop.pub_key)
+            new_fee_msat = self.get_fee_msat(amount_to_forward_msat, dest_chan_id, hop.pub_key)
             hop.fee_msat = new_fee_msat
             hop.fee = new_fee_msat / 1000
             additional_fees += new_fee_msat - fee_msat_before
+            dest_chan_id = hop.chan_id
 
     def get_expiry_delta_last_hop(self):
         return self.payment.cltv_expiry
 
     def update_expiry(self, hops, total_time_lock):
+        dest_chan_id = self.rebalance_channel.chan_id
         for hop in reversed(hops):
             hop.expiry = total_time_lock
 
-            channel_id = hop.chan_id
             target_pubkey = hop.pub_key
-            policy = self.lnd.get_policy(channel_id, target_pubkey)
+            policy = self.lnd.get_policy(dest_chan_id, target_pubkey)
+            dest_chan_id = hop.chan_id
 
             time_lock_delta = policy.time_lock_delta
             total_time_lock += time_lock_delta


### PR DESCRIPTION
According to BOLT #7, the channel policy the forwarding node requests for the _outgoing_ channel needs to be used for calculating the fee and cltv expiry for that node
(see https://github.com/lightningnetwork/lightning-rfc/blob/4c12ae8a27846f47d4c837b1b1fcc9c5b7aed175/07-routing-gossip.md#routing-example)

This fixes occasional InsufficientFee or IncorrectCltvExpiry errors (or a slightly too high fee being paid) which could happen if a node on the route didn't use the same policy for both channels