### PR TITLE
Add a `requirements.txt` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ You need to have admin rights to control this node.
 By default this script connects to `localhost:10009`, using the macaroon file in `~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon`.
 If you need to change this, please have a look at the sources.
 
-You need to install Python and the gRPC dependencies:
+You need to install Python. The gRPC dependencies can be installed by running:
 
 ```
-$ pip install grpcio googleapis-common-protos
+$ pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+googleapis-common-protos==1.5.8
+grpcio==1.19.0
+protobuf==3.6.1
+six==1.12.0


### PR DESCRIPTION
I've captured the requirements and included them in a `requirements.txt` file as per standard practice with these sorts of tools. This should make it more straightforward for persons to download & run the scripts, and for contributors to add external modules/packages as needed later on.

The file can be modified by running `$ pip freeze > requirements.txt` from the project root folder, ideally from within a separate virtual environment for the project.