### PR TITLE
Add debug for request routes form lnd which is slow.

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -43,7 +43,9 @@ class Routes:
             self.request_routes(num_routes_to_request)
 
     def request_routes(self, num_routes_to_request):
+        debug("requesting {:d} routes from lnd, please wait.".format(num_routes_to_request))
         routes = self.lnd.get_routes(self.last_hop_channel.remote_pubkey, self.get_amount(), num_routes_to_request)
+        debug("lnd routes recevided, testing routes")
         self.num_requested_routes = num_routes_to_request
         for route in routes:
             modified_route = self.add_rebalance_channel(route)

--- a/routes.py
+++ b/routes.py
@@ -45,7 +45,7 @@ class Routes:
     def request_routes(self, num_routes_to_request):
         debug("requesting {:d} routes from lnd, please wait.".format(num_routes_to_request))
         routes = self.lnd.get_routes(self.last_hop_channel.remote_pubkey, self.get_amount(), num_routes_to_request)
-        debug("lnd routes recevided, testing routes")
+        debug("lnd returned {:d} routes that will now be tested".format(len(routes)))
         self.num_requested_routes = num_routes_to_request
         for route in routes:
             modified_route = self.add_rebalance_channel(route)


### PR DESCRIPTION
request_routes can be very slow (especially on raspberry pi), I think it be efficient to add a debug (it is a bit like progressbar that is missing)

https://github.com/C-Otto/rebalance-lnd/issues/26