### PR TITLE
Cache invoices based on the amount

### DIFF
--- a/lnd.py
+++ b/lnd.py
@@ -67,7 +67,13 @@ class Lnd:
             value=amount,
         )
         add_invoice_response = self.stub.AddInvoice(invoice_request)
-        return self.decode_payment_request(add_invoice_response.payment_request)
+        return add_invoice_response.payment_request
+
+    def decode_payment_request(self, payment_request):
+        request = ln.PayReqString(
+            pay_req=payment_request,
+        )
+        return self.stub.DecodePayReq(request)
 
     def decode_payment_request(self, payment_request):
         request = ln.PayReqString(

--- a/logic.py
+++ b/logic.py
@@ -137,14 +137,14 @@ class Logic:
                 os.remove(filename)
 
     def cached_invoice(self):
-        filename = "./payment_request_%s.txt" % self.amount
+        filename = "./payment_request_%s_%s.txt" % (self.last_hop_channel.chan_id, self.amount)
         try:
             return open(filename, 'r').read()
         except FileNotFoundError:
             return
 
     def cache_invoice(self, payment_request):
-        filename = "./payment_request_%s.txt" % self.amount
+        filename = "./payment_request_%s_%s.txt" % (self.last_hop_channel.chan_id, self.amount)
         f = open(filename, "w+")
         f.write(payment_request)
         f.close()


### PR DESCRIPTION
I think invoices should be cached. 

The reasoning is that when a rebalancing fails, you may want to try different `--from` settings but with the same amount. In such case, there's no point creating a new invoice and polluting the wallet. 

Do you think it makes sense including `last_hop_channel.chan_id` with a cached file name?

When I leave the amount unchanged but change `--to` settings I will essentially be paying an invoice with a different "memo" but the amount will be the same so technically it's not a big deal. I can change it though.

Also, I can put cache files into a separate folder.