### PR TITLE
Script cleanup

### DIFF
--- a/lnd.py
+++ b/lnd.py
@@ -3,16 +3,11 @@ import os
 from os.path import expanduser
 import codecs
 import grpc
-import sys
 from functools import cache
 
 from grpc_generated import router_pb2_grpc as lnrouterrpc, router_pb2 as lnrouter, rpc_pb2_grpc as lnrpc, rpc_pb2 as ln
 
 MESSAGE_SIZE_MB = 50 * 1024 * 1024
-
-
-def debug(message):
-    sys.stderr.write(message + "\n")
 
 
 class Lnd:

--- a/lnd.py
+++ b/lnd.py
@@ -31,10 +31,10 @@ class Lnd:
 
     @staticmethod
     def get_credentials(lnd_dir):
-        with open(lnd_dir + "/tls.cert", "rb") as f:
+        with open(f"{lnd_dir}/tls.cert", "rb") as f:
             tls_certificate = f.read()
         ssl_credentials = grpc.ssl_channel_credentials(tls_certificate)
-        with open(lnd_dir + "/data/chain/bitcoin/mainnet/admin.macaroon", "rb") as f:
+        with open(f"{lnd_dir}/data/chain/bitcoin/mainnet/admin.macaroon", "rb") as f:
             macaroon = codecs.encode(f.read(), "hex")
         auth_credentials = grpc.metadata_call_credentials(
             lambda _, callback: callback([("macaroon", macaroon)], None)

--- a/lnd.py
+++ b/lnd.py
@@ -30,9 +30,11 @@ class Lnd:
 
     @staticmethod
     def get_credentials(lnd_dir):
-        tls_certificate = open(lnd_dir + '/tls.cert', 'rb').read()
+        with open(lnd_dir + '/tls.cert', 'rb') as f:
+            tls_certificate = f.read()
         ssl_credentials = grpc.ssl_channel_credentials(tls_certificate)
-        macaroon = codecs.encode(open(lnd_dir + '/data/chain/bitcoin/mainnet/admin.macaroon', 'rb').read(), 'hex')
+        with open(lnd_dir + '/data/chain/bitcoin/mainnet/admin.macaroon', 'rb') as f:
+            macaroon = codecs.encode(f.read(), 'hex')
         auth_credentials = grpc.metadata_call_credentials(lambda _, callback: callback([('macaroon', macaroon)], None))
         combined_credentials = grpc.composite_channel_credentials(ssl_credentials, auth_credentials)
         return combined_credentials

--- a/logic.py
+++ b/logic.py
@@ -1,4 +1,3 @@
-import sys
 import math
 
 from routes import Routes
@@ -11,16 +10,16 @@ MAX_FEE_RATE = 1000
 
 class Logic:
     def __init__(
-            self,
-            lnd,
-            first_hop_channel,
-            last_hop_channel,
-            amount,
-            channel_ratio,
-            excluded,
-            max_fee_factor,
-            econ_fee,
-            econ_fee_factor
+        self,
+        lnd,
+        first_hop_channel,
+        last_hop_channel,
+        amount,
+        channel_ratio,
+        excluded,
+        max_fee_factor,
+        econ_fee,
+        econ_fee_factor,
     ):
         self.lnd = lnd
         self.first_hop_channel = first_hop_channel
@@ -39,25 +38,43 @@ class Logic:
     def rebalance(self):
         fee_limit_msat = self.get_fee_limit_msat()
         if self.last_hop_channel:
-            debug(("Sending {:,} satoshis to rebalance to channel with ID %d (%s)"
-                   % (self.last_hop_channel.chan_id, self.lnd.get_node_alias(self.last_hop_channel.remote_pubkey)))
-                  .format(self.amount))
+            debug(
+                (
+                    "Sending {:,} satoshis to rebalance to channel with ID %d (%s)"
+                    % (
+                        self.last_hop_channel.chan_id,
+                        self.lnd.get_node_alias(self.last_hop_channel.remote_pubkey),
+                    )
+                ).format(self.amount)
+            )
         else:
             debug("Sending {:,} satoshis.".format(self.amount))
         if self.channel_ratio != 0.5:
             debug("Channel ratio used is %d%%" % int(self.channel_ratio * 100))
         if self.first_hop_channel:
-            debug("Forced first channel has ID %d (%s)"
-                  % (self.first_hop_channel.chan_id, self.lnd.get_node_alias(self.first_hop_channel.remote_pubkey)))
+            debug(
+                "Forced first channel has ID %d (%s)"
+                % (
+                    self.first_hop_channel.chan_id,
+                    self.lnd.get_node_alias(self.first_hop_channel.remote_pubkey),
+                )
+            )
 
         payment_request = self.generate_invoice()
         min_fee_last_hop = None
         if self.econ_fee and self.first_hop_channel:
             policy_first_hop = self.lnd.get_policy_to(self.first_hop_channel.chan_id)
             fee_rate = policy_first_hop.fee_rate_milli_msat
-            min_fee_last_hop = self.econ_fee_factor * self.compute_fee(self.amount, fee_rate, policy_first_hop)
+            min_fee_last_hop = self.econ_fee_factor * self.compute_fee(
+                self.amount, fee_rate, policy_first_hop
+            )
         routes = Routes(
-            self.lnd, payment_request, self.first_hop_channel, self.last_hop_channel, fee_limit_msat, min_fee_last_hop
+            self.lnd,
+            payment_request,
+            self.first_hop_channel,
+            self.last_hop_channel,
+            fee_limit_msat,
+            min_fee_last_hop,
         )
 
         self.initialize_ignored_channels(routes)
@@ -78,12 +95,18 @@ class Logic:
             policy = self.lnd.get_policy_to(self.last_hop_channel.chan_id)
             fee_rate = policy.fee_rate_milli_msat
             if fee_rate > MAX_FEE_RATE:
-                debug("Calculating using capped fee rate %s for inbound channel (original fee rate %s)"
-                      % (MAX_FEE_RATE, fee_rate))
+                debug(
+                    "Calculating using capped fee rate %s for inbound channel (original fee rate %s)"
+                    % (MAX_FEE_RATE, fee_rate)
+                )
                 fee_rate = MAX_FEE_RATE
-            fee_limit_msat = self.econ_fee_factor * self.compute_fee(self.amount, fee_rate, policy)
-            debug("Setting fee limit to %s (due to --econ-fee, factor %s)"
-                  % (int(fee_limit_msat), self.econ_fee_factor))
+            fee_limit_msat = self.econ_fee_factor * self.compute_fee(
+                self.amount, fee_rate, policy
+            )
+            debug(
+                "Setting fee limit to %s (due to --econ-fee, factor %s)"
+                % (int(fee_limit_msat), self.econ_fee_factor)
+            )
 
         return fee_limit_msat
 
@@ -104,7 +127,10 @@ class Logic:
             debug("")
             debug("")
             debug("")
-            debug("Decreased inbound liquidity on %s by %d sats" % (last_hop_alias, route.hops[-1].amt_to_forward))
+            debug(
+                "Decreased inbound liquidity on %s by %d sats"
+                % (last_hop_alias, route.hops[-1].amt_to_forward)
+            )
             debug("Increased inbound liquidity on %s" % first_hop_alias)
             debug("Fee: %d sats" % route.total_fees)
             debug("")
@@ -140,7 +166,9 @@ class Logic:
         if response.failure.failure_source_index == 0:
             failure_source_pubkey = route.hops[-1].pub_key
         else:
-            failure_source_pubkey = route.hops[response.failure.failure_source_index - 1].pub_key
+            failure_source_pubkey = route.hops[
+                response.failure.failure_source_index - 1
+            ].pub_key
         return failure_source_pubkey
 
     def route_is_invalid(self, route, routes):
@@ -153,12 +181,18 @@ class Logic:
         if self.first_hop_and_last_hop_use_same_channel(first_hop, last_hop):
             debugnobreak("Outbound and inbound channel are identical, ")
             hop_before_last_hop = route.hops[-2]
-            routes.ignore_edge_from_to(last_hop.chan_id, hop_before_last_hop.pub_key, last_hop.pub_key)
+            routes.ignore_edge_from_to(
+                last_hop.chan_id, hop_before_last_hop.pub_key, last_hop.pub_key
+            )
             return True
         if self.high_local_ratio_after_receiving(last_hop):
-            debugnobreak("Inbound channel would have high local ratio after receiving, ")
+            debugnobreak(
+                "Inbound channel would have high local ratio after receiving, "
+            )
             hop_before_last_hop = route.hops[-2]
-            routes.ignore_edge_from_to(last_hop.chan_id, hop_before_last_hop.pub_key, last_hop.pub_key)
+            routes.ignore_edge_from_to(
+                last_hop.chan_id, hop_before_last_hop.pub_key, last_hop.pub_key
+            )
             return True
         if self.fees_too_high(route):
             routes.ignore_high_fee_hops(route)
@@ -203,42 +237,55 @@ class Logic:
         if self.econ_fee:
             return self.fees_too_high_econ_fee(route)
         hops_with_fees = len(route.hops) - 1
-        lnd_fees = hops_with_fees * (DEFAULT_BASE_FEE_SAT_MSAT + (self.amount * DEFAULT_FEE_RATE_MSAT))
+        lnd_fees = hops_with_fees * (
+            DEFAULT_BASE_FEE_SAT_MSAT + (self.amount * DEFAULT_FEE_RATE_MSAT)
+        )
         limit = self.max_fee_factor * lnd_fees
         high_fees = route.total_fees_msat > limit
         if high_fees:
-            debugnobreak("High fees (%s sat over limit of %s), "
-                         % (int((route.total_fees_msat - limit) / 1000), int(limit/1000)))
+            debugnobreak(
+                "High fees (%s sat over limit of %s), "
+                % (int((route.total_fees_msat - limit) / 1000), int(limit / 1000))
+            )
         return high_fees
 
     def fees_too_high_econ_fee(self, route):
         policy_first_hop = self.lnd.get_policy_to(route.hops[0].chan_id)
         amount = route.total_amt
-        missed_fee = self.compute_fee(amount, policy_first_hop.fee_rate_milli_msat, policy_first_hop)
+        missed_fee = self.compute_fee(
+            amount, policy_first_hop.fee_rate_milli_msat, policy_first_hop
+        )
         policy_last_hop = self.lnd.get_policy_to(route.hops[-1].chan_id)
         fee_rate_last_hop = policy_last_hop.fee_rate_milli_msat
         original_fee_rate_last_hop = fee_rate_last_hop
         if fee_rate_last_hop > MAX_FEE_RATE:
             fee_rate_last_hop = MAX_FEE_RATE
-        expected_fee = self.econ_fee_factor * self.compute_fee(amount, fee_rate_last_hop, policy_last_hop)
+        expected_fee = self.econ_fee_factor * self.compute_fee(
+            amount, fee_rate_last_hop, policy_last_hop
+        )
         rebalance_fee = route.total_fees
         high_fees = rebalance_fee + missed_fee > expected_fee
         if high_fees:
             difference = rebalance_fee + missed_fee - expected_fee
             if fee_rate_last_hop != original_fee_rate_last_hop:
-                debug("Calculating using capped fee rate %s for inbound channel (original fee rate %s)"
-                      % (MAX_FEE_RATE, original_fee_rate_last_hop))
-            debugnobreak("High fees ("
-                         "%s expected future fee income for inbound channel (factor %s), "
-                         "have to pay %s now, "
-                         "missing out on %s future fees for outbound channel, "
-                         "difference %s), " % (
-                             math.floor(expected_fee),
-                             self.econ_fee_factor,
-                             int(rebalance_fee),
-                             math.ceil(missed_fee),
-                             math.ceil(difference)
-                         ))
+                debug(
+                    "Calculating using capped fee rate %s for inbound channel (original fee rate %s)"
+                    % (MAX_FEE_RATE, original_fee_rate_last_hop)
+                )
+            debugnobreak(
+                "High fees ("
+                "%s expected future fee income for inbound channel (factor %s), "
+                "have to pay %s now, "
+                "missing out on %s future fees for outbound channel, "
+                "difference %s), "
+                % (
+                    math.floor(expected_fee),
+                    self.econ_fee_factor,
+                    int(rebalance_fee),
+                    math.ceil(missed_fee),
+                    math.ceil(difference),
+                )
+            )
         return high_fees
 
     @staticmethod
@@ -256,9 +303,9 @@ class Logic:
     def get_channel_for_channel_id(self, channel_id):
         for channel in self.lnd.get_channels():
             if channel.chan_id == channel_id:
-                if not hasattr(channel, 'local_balance'):
+                if not hasattr(channel, "local_balance"):
                     channel.local_balance = 0
-                if not hasattr(channel, 'remote_balance'):
+                if not hasattr(channel, "remote_balance"):
                     channel.remote_balance = 0
                 return channel
         debug("Unable to find channel with id %d!" % channel_id)
@@ -268,14 +315,18 @@ class Logic:
             chan_id = self.first_hop_channel.chan_id
             from_pub_key = self.first_hop_channel.remote_pubkey
             to_pub_key = self.lnd.get_own_pubkey()
-            routes.ignore_edge_from_to(chan_id, from_pub_key, to_pub_key, show_message=False)
+            routes.ignore_edge_from_to(
+                chan_id, from_pub_key, to_pub_key, show_message=False
+            )
             if not self.last_hop_channel:
                 self.ignore_last_hops_with_high_ratio(routes)
         if self.last_hop_channel:
             chan_id = self.last_hop_channel.chan_id
             from_pub_key = self.lnd.get_own_pubkey()
             to_pub_key = self.last_hop_channel.remote_pubkey
-            routes.ignore_edge_from_to(chan_id, from_pub_key, to_pub_key, show_message=False)
+            routes.ignore_edge_from_to(
+                chan_id, from_pub_key, to_pub_key, show_message=False
+            )
             if self.econ_fee:
                 self.ignore_first_hops_with_fee_rate_higher_than_last_hop(routes)
         for channel in self.lnd.get_channels():
@@ -294,7 +345,9 @@ class Logic:
             policy = self.lnd.get_policy_to(chan_id)
             if policy.fee_rate_milli_msat > last_hop_fee_rate:
                 to_pub_key = channel.remote_pubkey
-                routes.ignore_edge_from_to(chan_id, from_pub_key, to_pub_key, show_message=False)
+                routes.ignore_edge_from_to(
+                    chan_id, from_pub_key, to_pub_key, show_message=False
+                )
 
     def ignore_last_hops_with_high_ratio(self, routes):
         for channel in self.lnd.get_channels():
@@ -306,4 +359,6 @@ class Logic:
             ratio = float(local) / (remote + local)
             if ratio > self.channel_ratio:
                 to_pub_key = self.lnd.get_own_pubkey()
-                routes.ignore_edge_from_to(channel_id, channel.remote_pubkey, to_pub_key, show_message=False)
+                routes.ignore_edge_from_to(
+                    channel_id, channel.remote_pubkey, to_pub_key, show_message=False
+                )

--- a/logic.py
+++ b/logic.py
@@ -39,25 +39,17 @@ class Logic:
         fee_limit_msat = self.get_fee_limit_msat()
         if self.last_hop_channel:
             debug(
-                (
-                    "Sending {:,} satoshis to rebalance to channel with ID %d (%s)"
-                    % (
-                        self.last_hop_channel.chan_id,
-                        self.lnd.get_node_alias(self.last_hop_channel.remote_pubkey),
-                    )
-                ).format(self.amount)
+                f"Sending {self.amount:,} satoshis to rebalance to channel with ID "
+                f"{self.last_hop_channel.chan_id} ({self.lnd.get_node_alias(self.last_hop_channel.remote_pubkey)})"
             )
         else:
-            debug("Sending {:,} satoshis.".format(self.amount))
+            debug(f"Sending {self.amount:,} satoshis.")
         if self.channel_ratio != 0.5:
-            debug("Channel ratio used is %d%%" % int(self.channel_ratio * 100))
+            debug(f"Channel ratio used is {int(self.channel_ratio * 100)}%")
         if self.first_hop_channel:
             debug(
-                "Forced first channel has ID %d (%s)"
-                % (
-                    self.first_hop_channel.chan_id,
-                    self.lnd.get_node_alias(self.first_hop_channel.remote_pubkey),
-                )
+                f"Forced first channel has ID {self.first_hop_channel.chan_id} "
+                f"({self.lnd.get_node_alias(self.first_hop_channel.remote_pubkey)})"
             )
 
         payment_request = self.generate_invoice()
@@ -96,16 +88,16 @@ class Logic:
             fee_rate = policy.fee_rate_milli_msat
             if fee_rate > MAX_FEE_RATE:
                 debug(
-                    "Calculating using capped fee rate %s for inbound channel (original fee rate %s)"
-                    % (MAX_FEE_RATE, fee_rate)
+                    f"Calculating using capped fee rate {MAX_FEE_RATE} "
+                    f"for inbound channel (original fee rate {fee_rate})"
                 )
                 fee_rate = MAX_FEE_RATE
             fee_limit_msat = self.econ_fee_factor * self.compute_fee(
                 self.amount, fee_rate, policy
             )
             debug(
-                "Setting fee limit to %s (due to --econ-fee, factor %s)"
-                % (int(fee_limit_msat), self.econ_fee_factor)
+                f"Setting fee limit to {int(fee_limit_msat)} "
+                f"(due to --econ-fee, factor {self.econ_fee_factor})"
             )
 
         return fee_limit_msat
@@ -116,7 +108,7 @@ class Logic:
 
         tried_routes.append(route)
         debug("")
-        debug("Trying route #%d" % len(tried_routes))
+        debug(f"Trying route #{len(tried_routes)}")
         debug(Routes.print_route(route))
 
         response = self.lnd.send_payment(payment_request, route)
@@ -128,11 +120,11 @@ class Logic:
             debug("")
             debug("")
             debug(
-                "Decreased inbound liquidity on %s by %d sats"
-                % (last_hop_alias, route.hops[-1].amt_to_forward)
+                f"Decreased inbound liquidity on {last_hop_alias} by "
+                f"{int(route.hops[-1].amt_to_forward)} sats"
             )
-            debug("Increased inbound liquidity on %s" % first_hop_alias)
-            debug("Fee: %d sats" % route.total_fees)
+            debug(f"Increased inbound liquidity on {first_hop_alias}")
+            debug(f"Fee: {route.total_fees} sats")
             debug("")
             debug("Successful route:")
             debug(Routes.print_route(route))
@@ -159,7 +151,7 @@ class Logic:
             routes.ignore_edge_on_route(failure_source_pubkey, route)
         else:
             debug(repr(response))
-            debug("Unknown error code %s" % repr(code))
+            debug(f"Unknown error code {repr(code)}")
 
     @staticmethod
     def get_failure_source_pubkey(response, route):
@@ -206,7 +198,7 @@ class Logic:
         channel_id = first_hop.chan_id
         channel = self.get_channel_for_channel_id(channel_id)
         if channel is None:
-            debug("Unable to get channel information for hop %s" % repr(first_hop))
+            debug(f"Unable to get channel information for hop {repr(first_hop)}")
             return True
 
         remote = channel.remote_balance + total_amount
@@ -220,7 +212,7 @@ class Logic:
         channel_id = last_hop.chan_id
         channel = self.get_channel_for_channel_id(channel_id)
         if channel is None:
-            debug("Unable to get channel information for hop %s" % repr(last_hop))
+            debug(f"Unable to get channel information for hop {repr(last_hop)}")
             return True
 
         amount = last_hop.amt_to_forward
@@ -244,8 +236,8 @@ class Logic:
         high_fees = route.total_fees_msat > limit
         if high_fees:
             debugnobreak(
-                "High fees (%s sat over limit of %s), "
-                % (int((route.total_fees_msat - limit) / 1000), int(limit / 1000))
+                f"High fees ({int((route.total_fees_msat - limit) / 1000)} "
+                f"sat over limit of {int(limit / 1000)}), "
             )
         return high_fees
 
@@ -269,22 +261,13 @@ class Logic:
             difference = rebalance_fee + missed_fee - expected_fee
             if fee_rate_last_hop != original_fee_rate_last_hop:
                 debug(
-                    "Calculating using capped fee rate %s for inbound channel (original fee rate %s)"
-                    % (MAX_FEE_RATE, original_fee_rate_last_hop)
+                    f"Calculating using capped fee rate {MAX_FEE_RATE} for inbound channel "
+                    f"(original fee rate {original_fee_rate_last_hop})"
                 )
             debugnobreak(
-                "High fees ("
-                "%s expected future fee income for inbound channel (factor %s), "
-                "have to pay %s now, "
-                "missing out on %s future fees for outbound channel, "
-                "difference %s), "
-                % (
-                    math.floor(expected_fee),
-                    self.econ_fee_factor,
-                    int(rebalance_fee),
-                    math.ceil(missed_fee),
-                    math.ceil(difference),
-                )
+                f"High fees ({math.floor(expected_fee)} expected future fee income for inbound channel "
+                f"(factor {self.econ_fee_factor}), have to pay {int(rebalance_fee)} now, missing out on "
+                f"{math.ceil(missed_fee)} future fees for outbound channel, difference {math.ceil(difference)}), "
             )
         return high_fees
 
@@ -295,9 +278,9 @@ class Logic:
 
     def generate_invoice(self):
         if self.last_hop_channel:
-            memo = "Rebalance of channel with ID %d" % self.last_hop_channel.chan_id
+            memo = f"Rebalance of channel with ID {self.last_hop_channel.chan_id}"
         else:
-            memo = "Rebalance of channel with ID %d" % self.first_hop_channel.chan_id
+            memo = f"Rebalance of channel with ID {self.first_hop_channel.chan_id}"
         return self.lnd.generate_invoice(memo, self.amount)
 
     def get_channel_for_channel_id(self, channel_id):
@@ -308,7 +291,7 @@ class Logic:
                 if not hasattr(channel, "remote_balance"):
                     channel.remote_balance = 0
                 return channel
-        debug("Unable to find channel with id %d!" % channel_id)
+        debug(f"Unable to find channel with id {channel_id}!")
 
     def initialize_ignored_channels(self, routes):
         if self.first_hop_channel:

--- a/logic.py
+++ b/logic.py
@@ -2,18 +2,11 @@ import sys
 import math
 
 from routes import Routes
+from utils import debug, debugnobreak
 
 DEFAULT_BASE_FEE_SAT_MSAT = 1000
 DEFAULT_FEE_RATE_MSAT = 0.001
 MAX_FEE_RATE = 1000
-
-
-def debug(message):
-    sys.stderr.write(message + "\n")
-
-
-def debugnobreak(message):
-    sys.stderr.write(message)
 
 
 class Logic:

--- a/rebalance.py
+++ b/rebalance.py
@@ -112,10 +112,8 @@ def get_amount(arguments, first_hop_channel, last_hop_channel):
         remote_surplus = get_remote_surplus(last_hop_channel)
         if remote_surplus < 0:
             print(
-                "Error: last hop needs to SEND {:,} sat to be balanced, you want it to RECEIVE funds. "
-                "Specify amount manually if this was intended.".format(
-                    abs(remote_surplus)
-                )
+                f"Error: last hop needs to SEND {abs(remote_surplus):,} sat to be balanced, you want it to RECEIVE funds. "
+                "Specify amount manually if this was intended."
             )
             return 0
     else:
@@ -123,8 +121,8 @@ def get_amount(arguments, first_hop_channel, last_hop_channel):
         remote_surplus = get_remote_surplus(first_hop_channel)
         if remote_surplus > 0:
             print(
-                "Error: first hop needs to RECEIVE {:,} sat to be balanced, you want it to SEND funds. "
-                "Specify amount manually if this was intended.".format(remote_surplus)
+                f"Error: first hop needs to RECEIVE {remote_surplus:,} sat to be balanced, you want it to SEND funds. "
+                "Specify amount manually if this was intended."
             )
             return 0
 
@@ -297,21 +295,21 @@ def list_candidates(lnd, candidates):
             0, candidate.local_balance - candidate.local_chan_reserve_sat
         )
         rebalance_amount_int = get_rebalance_amount(candidate)
-        rebalance_amount = "{:,}".format(rebalance_amount_int)
+        rebalance_amount = f"{rebalance_amount_int:,}"
         if rebalance_amount_int > MAX_SATOSHIS_PER_TRANSACTION:
-            rebalance_amount += " (max per transaction: {:,})".format(
-                MAX_SATOSHIS_PER_TRANSACTION
+            rebalance_amount += (
+                " (max per transaction: {MAX_SATOSHIS_PER_TRANSACTION:,})"
             )
 
-        print("(%2d) Channel ID:  " % index + str(candidate.chan_id))
-        print("Alias:            " + lnd.get_node_alias(candidate.remote_pubkey))
-        print("Pubkey:           " + candidate.remote_pubkey)
-        print("Channel Point:    " + candidate.channel_point)
-        print("Local ratio:      {:.3f}".format(get_local_ratio(candidate)))
-        print("Capacity:         {:,}".format(candidate.capacity))
-        print("Remote available: {:,}".format(remote_available))
-        print("Local available:  {:,}".format(local_available))
-        print("Amount for 50-50: " + rebalance_amount)
+        print(f"({index:2}) Channel ID:  {str(candidate.chan_id)}")
+        print(f"Alias:            {lnd.get_node_alias(candidate.remote_pubkey)}")
+        print(f"Pubkey:           {candidate.remote_pubkey}")
+        print(f"Channel Point:    {candidate.channel_point}")
+        print(f"Local ratio:      {get_local_ratio(candidate):.3f}")
+        print(f"Capacity:         {candidate.capacity:,}")
+        print(f"Remote available: {remote_available:,}")
+        print(f"Local available:  {local_available:,}")
+        print(f"Amount for 50-50: {rebalance_amount}")
         print(get_capacity_and_ratio_bar(candidate))
         print("")
 
@@ -365,7 +363,7 @@ def get_capacity_and_ratio_bar(candidate):
         result += "="
     for _ in range(length, bar_width):
         result += " "
-    return result + "|"
+    return f"{result}|"
 
 
 def get_columns():

--- a/rebalance.py
+++ b/rebalance.py
@@ -4,8 +4,8 @@ import argparse
 import math
 import os
 import platform
-import sys
 import random
+import sys
 
 from lnd import Lnd
 from logic import Logic
@@ -18,7 +18,7 @@ def main():
     argument_parser = get_argument_parser()
     arguments = argument_parser.parse_args()
     lnd = Lnd(arguments.lnddir, arguments.grpc)
-    first_hop_channel_id = vars(arguments)['from']
+    first_hop_channel_id = vars(arguments)["from"]
     to_channel = arguments.to
 
     if arguments.ratio < 1 or arguments.ratio > 50:
@@ -27,7 +27,9 @@ def main():
     channel_ratio = float(arguments.ratio) / 100
 
     if arguments.incoming is not None and not arguments.list_candidates:
-        print("--outgoing and --incoming only work in conjunction with --list-candidates")
+        print(
+            "--outgoing and --incoming only work in conjunction with --list-candidates"
+        )
         sys.exit(1)
 
     if arguments.list_candidates:
@@ -56,7 +58,9 @@ def main():
         last_hop_channel = get_incoming_rebalance_candidates(lnd, channel_ratio)[index]
     elif to_channel == -1:
         # here is the random case
-        last_hop_channel = random.choice(get_incoming_rebalance_candidates(lnd, channel_ratio))
+        last_hop_channel = random.choice(
+            get_incoming_rebalance_candidates(lnd, channel_ratio)
+        )
     else:
         # else the channel argument should be the channel ID
         last_hop_channel = get_channel_for_channel_id(lnd, to_channel)
@@ -69,7 +73,9 @@ def main():
         first_hop_channel = candidates[index]
     elif first_hop_channel_id == -1:
         # here is the random case
-        last_hop_channel = random.choice(get_incoming_rebalance_candidates(lnd, channel_ratio))
+        last_hop_channel = random.choice(
+            get_incoming_rebalance_candidates(lnd, channel_ratio)
+        )
     else:
         # else the channel argument should be the channel ID
         first_hop_channel = get_channel_for_channel_id(lnd, first_hop_channel_id)
@@ -84,8 +90,17 @@ def main():
     econ_fee = arguments.econ_fee
     econ_fee_factor = arguments.econ_fee_factor
     excluded = arguments.exclude
-    return Logic(lnd, first_hop_channel, last_hop_channel, amount, channel_ratio, excluded,
-                 max_fee_factor, econ_fee, econ_fee_factor).rebalance()
+    return Logic(
+        lnd,
+        first_hop_channel,
+        last_hop_channel,
+        amount,
+        channel_ratio,
+        excluded,
+        max_fee_factor,
+        econ_fee,
+        econ_fee_factor,
+    ).rebalance()
 
 
 def get_amount(arguments, first_hop_channel, last_hop_channel):
@@ -96,15 +111,21 @@ def get_amount(arguments, first_hop_channel, last_hop_channel):
         amount = get_rebalance_amount(last_hop_channel)
         remote_surplus = get_remote_surplus(last_hop_channel)
         if remote_surplus < 0:
-            print("Error: last hop needs to SEND {:,} sat to be balanced, you want it to RECEIVE funds. "
-                  "Specify amount manually if this was intended.".format(abs(remote_surplus)))
+            print(
+                "Error: last hop needs to SEND {:,} sat to be balanced, you want it to RECEIVE funds. "
+                "Specify amount manually if this was intended.".format(
+                    abs(remote_surplus)
+                )
+            )
             return 0
     else:
         amount = get_rebalance_amount(first_hop_channel)
         remote_surplus = get_remote_surplus(first_hop_channel)
         if remote_surplus > 0:
-            print("Error: first hop needs to RECEIVE {:,} sat to be balanced, you want it to SEND funds. "
-                  "Specify amount manually if this was intended.".format(remote_surplus))
+            print(
+                "Error: first hop needs to RECEIVE {:,} sat to be balanced, you want it to SEND funds. "
+                "Specify amount manually if this was intended.".format(remote_surplus)
+            )
             return 0
 
     if arguments.percentage:
@@ -128,84 +149,130 @@ def get_channel_for_channel_id(lnd, channel_id):
 
 def get_argument_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--lnddir",
-                        default="~/.lnd",
-                        dest="lnddir",
-                        help="(default ~/.lnd) lnd directory")
-    parser.add_argument("--grpc",
-                        default="localhost:10009",
-                        dest="grpc",
-                        help="(default localhost:10009) lnd gRPC endpoint")
-    parser.add_argument("-r", "--ratio",
-                        type=int,
-                        default=50,
-                        help="(default: 50) ratio for channel imbalance between 1 and 50, "
-                             "eg. 45 to only show channels (-l) with less than 45%% of the "
-                             "funds on the local (-i) or remote (-o) side")
-    list_group = parser.add_argument_group("list candidates", "Show the unbalanced channels.")
-    list_group.add_argument("-l", "--list-candidates", action="store_true",
-                            help="list candidate channels for rebalance")
+    parser.add_argument(
+        "--lnddir",
+        default="~/.lnd",
+        dest="lnddir",
+        help="(default ~/.lnd) lnd directory",
+    )
+    parser.add_argument(
+        "--grpc",
+        default="localhost:10009",
+        dest="grpc",
+        help="(default localhost:10009) lnd gRPC endpoint",
+    )
+    parser.add_argument(
+        "-r",
+        "--ratio",
+        type=int,
+        default=50,
+        help="(default: 50) ratio for channel imbalance between 1 and 50, "
+        "eg. 45 to only show channels (-l) with less than 45%% of the "
+        "funds on the local (-i) or remote (-o) side",
+    )
+    list_group = parser.add_argument_group(
+        "list candidates", "Show the unbalanced channels."
+    )
+    list_group.add_argument(
+        "-l",
+        "--list-candidates",
+        action="store_true",
+        help="list candidate channels for rebalance",
+    )
 
     direction_group = list_group.add_mutually_exclusive_group()
-    direction_group.add_argument("-o", "--outgoing",
-                                 action="store_const",
-                                 const=False,
-                                 dest="incoming",
-                                 help="lists channels with less than x%% of the funds on the remote side (see --ratio)")
-    direction_group.add_argument("-i", "--incoming",
-                                 action="store_const",
-                                 const=True,
-                                 dest="incoming",
-                                 help="(default) lists channels with less than x%% of the funds on the local side "
-                                      "(see --ratio)")
+    direction_group.add_argument(
+        "-o",
+        "--outgoing",
+        action="store_const",
+        const=False,
+        dest="incoming",
+        help="lists channels with less than x%% of the funds on the remote side (see --ratio)",
+    )
+    direction_group.add_argument(
+        "-i",
+        "--incoming",
+        action="store_const",
+        const=True,
+        dest="incoming",
+        help="(default) lists channels with less than x%% of the funds on the local side "
+        "(see --ratio)",
+    )
 
-    rebalance_group = parser.add_argument_group("rebalance",
-                                                "Rebalance a channel. You need to specify at least"
-                                                " the 'from' channel (-f) or the 'to' channel (-t).")
-    rebalance_group.add_argument("-f", "--from",
-                                 metavar="CHANNEL",
-                                 type=int,
-                                 help="Channel ID of the outgoing channel "
-                                      "(funds will be taken from this channel). "
-                                      "You may also use the index as shown in the incoming candidate list (-l -o), "
-                                      "or -1 to choose a random candidate.")
-    rebalance_group.add_argument("-t", "--to",
-                                 metavar="CHANNEL",
-                                 type=int,
-                                 help="Channel ID of the incoming channel "
-                                      "(funds will be sent to this channel). "
-                                      "You may also use the index as shown in the incoming candidate list (-l -i), "
-                                      "or -1 to choose a random candidate.")
+    rebalance_group = parser.add_argument_group(
+        "rebalance",
+        "Rebalance a channel. You need to specify at least"
+        " the 'from' channel (-f) or the 'to' channel (-t).",
+    )
+    rebalance_group.add_argument(
+        "-f",
+        "--from",
+        metavar="CHANNEL",
+        type=int,
+        help="Channel ID of the outgoing channel "
+        "(funds will be taken from this channel). "
+        "You may also use the index as shown in the incoming candidate list (-l -o), "
+        "or -1 to choose a random candidate.",
+    )
+    rebalance_group.add_argument(
+        "-t",
+        "--to",
+        metavar="CHANNEL",
+        type=int,
+        help="Channel ID of the incoming channel "
+        "(funds will be sent to this channel). "
+        "You may also use the index as shown in the incoming candidate list (-l -i), "
+        "or -1 to choose a random candidate.",
+    )
     amount_group = rebalance_group.add_mutually_exclusive_group()
-    amount_group.add_argument("-a", "--amount",
-                              type=int,
-                              help="Amount of the rebalance, in satoshis. If not specified, "
-                                   "the amount computed for a perfect rebalance will be used"
-                                   " (up to the maximum of 4,294,967 satoshis)")
-    amount_group.add_argument("-p", "--percentage",
-                              type=int,
-                              help="Set the amount to send to a percentage of the amount required to rebalance. "
-                                   "As an example, if this is set to 50, the amount will half of the default. "
-                                   "See --amount.")
-    rebalance_group.add_argument("-e", "--exclude",
-                                 type=int,
-                                 action="append",
-                                 help="Exclude the given channel ID as the outgoing channel (no funds will be taken "
-                                      "out of excluded channels)")
+    amount_group.add_argument(
+        "-a",
+        "--amount",
+        type=int,
+        help="Amount of the rebalance, in satoshis. If not specified, "
+        "the amount computed for a perfect rebalance will be used"
+        " (up to the maximum of 4,294,967 satoshis)",
+    )
+    amount_group.add_argument(
+        "-p",
+        "--percentage",
+        type=int,
+        help="Set the amount to send to a percentage of the amount required to rebalance. "
+        "As an example, if this is set to 50, the amount will half of the default. "
+        "See --amount.",
+    )
+    rebalance_group.add_argument(
+        "-e",
+        "--exclude",
+        type=int,
+        action="append",
+        help="Exclude the given channel ID as the outgoing channel (no funds will be taken "
+        "out of excluded channels)",
+    )
     fee_group = rebalance_group.add_mutually_exclusive_group()
-    fee_group.add_argument("--max-fee-factor",
-                                 type=float,
-                                 default=10,
-                                 help="(default: 10) Reject routes that cost more than x times the lnd default "
-                                      "(base: 1 sat, rate: 1 millionth sat) per hop on average")
-    fee_group.add_argument('--econ-fee', default=False, action='store_true',
-                           help="(default: disabled) Economy Fee Mode, see README.md")
-    rebalance_group.add_argument('--econ-fee-factor', default=1.0, type=float,
-                                 help="(default: 1.0) When using --econ-fee, compare the costs against the expected "
-                                      "income, scaled by this factor. As an example, with --econ-fee-factor 1.5, "
-                                      "routes that cost at most 150%% of the expected earnings are tried. Use values "
-                                      "smaller than 1.0 to restrict routes to only consider those earning "
-                                      "more/costing less.")
+    fee_group.add_argument(
+        "--max-fee-factor",
+        type=float,
+        default=10,
+        help="(default: 10) Reject routes that cost more than x times the lnd default "
+        "(base: 1 sat, rate: 1 millionth sat) per hop on average",
+    )
+    fee_group.add_argument(
+        "--econ-fee",
+        default=False,
+        action="store_true",
+        help="(default: disabled) Economy Fee Mode, see README.md",
+    )
+    rebalance_group.add_argument(
+        "--econ-fee-factor",
+        default=1.0,
+        type=float,
+        help="(default: 1.0) When using --econ-fee, compare the costs against the expected "
+        "income, scaled by this factor. As an example, with --econ-fee-factor 1.5, "
+        "routes that cost at most 150%% of the expected earnings are tried. Use values "
+        "smaller than 1.0 to restrict routes to only consider those earning "
+        "more/costing less.",
+    )
     return parser
 
 
@@ -223,12 +290,18 @@ def list_candidates(lnd, candidates):
     index = 0
     for candidate in candidates:
         index += 1
-        remote_available = max(0, candidate.remote_balance - candidate.remote_chan_reserve_sat)
-        local_available = max(0, candidate.local_balance - candidate.local_chan_reserve_sat)
+        remote_available = max(
+            0, candidate.remote_balance - candidate.remote_chan_reserve_sat
+        )
+        local_available = max(
+            0, candidate.local_balance - candidate.local_chan_reserve_sat
+        )
         rebalance_amount_int = get_rebalance_amount(candidate)
         rebalance_amount = "{:,}".format(rebalance_amount_int)
         if rebalance_amount_int > MAX_SATOSHIS_PER_TRANSACTION:
-            rebalance_amount += " (max per transaction: {:,})".format(MAX_SATOSHIS_PER_TRANSACTION)
+            rebalance_amount += " (max per transaction: {:,})".format(
+                MAX_SATOSHIS_PER_TRANSACTION
+            )
 
         print("(%2d) Channel ID:  " % index + str(candidate.chan_id))
         print("Alias:            " + lnd.get_node_alias(candidate.remote_pubkey))
@@ -253,12 +326,17 @@ def get_rebalance_candidates(lnd, pred, reverse):
     candidates = filter(lambda c: get_rebalance_amount(c) > 0, filtered)
     return sorted(candidates, key=get_remote_surplus, reverse=reverse)
 
+
 def get_incoming_rebalance_candidates(lnd, channel_ratio):
-    return get_rebalance_candidates(lnd, lambda c: get_local_ratio(c) < channel_ratio, False)
+    return get_rebalance_candidates(
+        lnd, lambda c: get_local_ratio(c) < channel_ratio, False
+    )
 
 
 def get_outgoing_rebalance_candidates(lnd, channel_ratio):
-    return get_rebalance_candidates(lnd, lambda c: get_local_ratio(c) > 1 - channel_ratio, True)
+    return get_rebalance_candidates(
+        lnd, lambda c: get_local_ratio(c) > 1 - channel_ratio, True
+    )
 
 
 def get_local_ratio(channel):
@@ -273,7 +351,9 @@ def get_remote_surplus(channel):
 
 def get_capacity_and_ratio_bar(candidate):
     columns = get_columns()
-    columns_scaled_to_capacity = int(round(columns * float(candidate.capacity) / MAX_CHANNEL_CAPACITY))
+    columns_scaled_to_capacity = int(
+        round(columns * float(candidate.capacity) / MAX_CHANNEL_CAPACITY)
+    )
     if candidate.capacity >= MAX_CHANNEL_CAPACITY:
         columns_scaled_to_capacity = columns
 
@@ -289,8 +369,8 @@ def get_capacity_and_ratio_bar(candidate):
 
 
 def get_columns():
-    if platform.system() == 'Linux' and sys.__stdin__.isatty():
-        return int(os.popen('stty size', 'r').read().split()[1])
+    if platform.system() == "Linux" and sys.__stdin__.isatty():
+        return int(os.popen("stty size", "r").read().split()[1])
     else:
         return 80
 

--- a/rebalance.py
+++ b/rebalance.py
@@ -247,18 +247,18 @@ def get_rebalance_amount(channel):
     return abs(int(math.ceil(float(get_remote_surplus(channel)) / 2)))
 
 
+def get_rebalance_candidates(lnd, pred, reverse):
+    active = filter(lambda c: c.active, lnd.get_channels())
+    filtered = filter(pred, active)
+    candidates = filter(lambda c: get_rebalance_amount(c) > 0, filtered)
+    return sorted(candidates, key=get_remote_surplus, reverse=reverse)
+
 def get_incoming_rebalance_candidates(lnd, channel_ratio):
-    active = list(filter(lambda c: c.active, lnd.get_channels()))
-    low_local = list(filter(lambda c: get_local_ratio(c) < channel_ratio, active))
-    low_local = list(filter(lambda c: get_rebalance_amount(c) > 0, low_local))
-    return sorted(low_local, key=get_remote_surplus, reverse=False)
+    return get_rebalance_candidates(lnd, lambda c: get_local_ratio(c) < channel_ratio, False)
 
 
 def get_outgoing_rebalance_candidates(lnd, channel_ratio):
-    active = list(filter(lambda c: c.active, lnd.get_channels()))
-    high_local = list(filter(lambda c: get_local_ratio(c) > 1 - channel_ratio, active))
-    high_local = list(filter(lambda c: get_rebalance_amount(c) > 0, high_local))
-    return sorted(high_local, key=get_remote_surplus, reverse=True)
+    return get_rebalance_candidates(lnd, lambda c: get_local_ratio(c) > 1 - channel_ratio, True)
 
 
 def get_local_ratio(channel):
@@ -281,9 +281,9 @@ def get_capacity_and_ratio_bar(candidate):
     result = "|"
     ratio = get_local_ratio(candidate)
     length = int(round(ratio * bar_width))
-    for x in range(0, length):
+    for _ in range(0, length):
         result += "="
-    for x in range(length, bar_width):
+    for _ in range(length, bar_width):
         result += " "
     return result + "|"
 

--- a/routes.py
+++ b/routes.py
@@ -1,15 +1,9 @@
 import base64
 import sys
 
+from utils import debug
+
 MAX_ROUTES_TO_REQUEST = 100
-
-
-def debug(message):
-    sys.stderr.write(message + "\n")
-
-
-def debugnobreak(message):
-    sys.stderr.write(message)
 
 
 class Routes:

--- a/routes.py
+++ b/routes.py
@@ -1,5 +1,4 @@
 import base64
-import sys
 
 from utils import debug
 
@@ -8,7 +7,13 @@ MAX_ROUTES_TO_REQUEST = 100
 
 class Routes:
     def __init__(
-            self, lnd, payment_request, first_hop_channel, last_hop_channel, fee_limit_msat, min_fee_msat_last_hop
+        self,
+        lnd,
+        payment_request,
+        first_hop_channel,
+        last_hop_channel,
+        fee_limit_msat,
+        min_fee_msat_last_hop,
     ):
         self.lnd = lnd
         self.payment_request = payment_request
@@ -52,8 +57,14 @@ class Routes:
             first_hop_channel_id = self.first_hop_channel.chan_id
         else:
             first_hop_channel_id = None
-        routes = self.lnd.get_route(last_hop_pubkey, amount, self.ignored_pairs,
-                                    self.ignored_nodes, first_hop_channel_id, self.fee_limit_msat)
+        routes = self.lnd.get_route(
+            last_hop_pubkey,
+            amount,
+            self.ignored_pairs,
+            self.ignored_nodes,
+            first_hop_channel_id,
+            self.fee_limit_msat,
+        )
         if routes is None:
             self.num_requested_routes = MAX_ROUTES_TO_REQUEST
         else:
@@ -84,7 +95,9 @@ class Routes:
         ignore_next = False
         for hop in route.hops:
             if ignore_next:
-                self.ignore_edge_from_to(hop.chan_id, failure_source_pubkey, hop.pub_key)
+                self.ignore_edge_from_to(
+                    hop.chan_id, failure_source_pubkey, hop.pub_key
+                )
                 return
             if hop.pub_key == failure_source_pubkey:
                 ignore_next = True
@@ -121,8 +134,14 @@ class Routes:
 
     def ignore_edge_from_to(self, chan_id, from_pubkey, to_pubkey, show_message=True):
         if show_message:
-            debug("ignoring channel %s (from %s to %s)" % (chan_id, from_pubkey, to_pubkey))
-        pair = {"from": base64.b16decode(from_pubkey, True), "to": base64.b16decode(to_pubkey, True)}
+            debug(
+                "ignoring channel %s (from %s to %s)"
+                % (chan_id, from_pubkey, to_pubkey)
+            )
+        pair = {
+            "from": base64.b16decode(from_pubkey, True),
+            "to": base64.b16decode(to_pubkey, True),
+        }
         self.ignored_pairs.append(pair)
 
     def ignore_node(self, pub_key):

--- a/routes.py
+++ b/routes.py
@@ -134,10 +134,7 @@ class Routes:
 
     def ignore_edge_from_to(self, chan_id, from_pubkey, to_pubkey, show_message=True):
         if show_message:
-            debug(
-                "ignoring channel %s (from %s to %s)"
-                % (chan_id, from_pubkey, to_pubkey)
-            )
+            debug(f"ignoring channel {chan_id} (from {from_pubkey} to {to_pubkey})")
         pair = {
             "from": base64.b16decode(from_pubkey, True),
             "to": base64.b16decode(to_pubkey, True),
@@ -145,5 +142,5 @@ class Routes:
         self.ignored_pairs.append(pair)
 
     def ignore_node(self, pub_key):
-        debug("ignoring node %s" % pub_key)
+        debug(f"ignoring node {pub_key}")
         self.ignored_nodes.append(base64.b16decode(pub_key, True))

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,9 @@
 import sys
 
+
 def debug(message):
     sys.stderr.write(message + "\n")
+
 
 def debugnobreak(message):
     sys.stderr.write(message)

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import sys
 
 
 def debug(message):
-    sys.stderr.write(message + "\n")
+    sys.stderr.write(f"{message}\n")
 
 
 def debugnobreak(message):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,7 @@
+import sys
+
+def debug(message):
+    sys.stderr.write(message + "\n")
+
+def debugnobreak(message):
+    sys.stderr.write(message)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR proposes a number of incremental changes that attempt to improve the maintainability of the script.

- Use `functools.cache` instead of manually caching members as self variables
- Deduplicate candidate selection functions and use lambda for filtering
- Close files opened with `open` automatically
- Use single definition for `debug` / `debugnobreak`
- Format the project using [black](https://github.com/psf/black) - this shouldn't affect functionality in any way, but it generated a big diff
- Convert all string formats to f-strings using [flynt](https://github.com/ikamensh/flynt) - no functionality change, but again, big diff