### PR TITLE
Add a RaspiBolt guide entry to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Aside from paid fees, your total liquidity does not change.
 
 ## Installation
 
-There are three options for installing rebalance-lnd.
+There are several options for installing rebalance-lnd.
 
-1. Using Python
-1. Using Docker
-1. Using Umbrel's app store
+1. [Using Python](#using-python)
+1. [Using Docker](#using-docker)
+1. [Using Umbrel's app store](#using-umbrels-app-store)
+1. [Using the RaspiBolt manual installation guide on any Debian-based OS](#using-the-raspibolt-guide) 
 
 ### Using Python
 
@@ -109,6 +110,10 @@ latest version. You may also delete everything and start over with a fresh insta
 any data that needs to be kept.
 
 Do not forget to update the Python dependencies as described above.
+
+### Using the RaspiBolt guide
+
+If you run a node on a Debian-based OS, you can follow the [RaspiBolt guide](https://raspibolt.org/bonus/lightning/rebalance-lnd.html) that explains how to manually install, use, update and uninstall rebalance-lnd on your node.
 
 # Usage
 


### PR DESCRIPTION
Hi @C-Otto,

We just published a new guide on the RaspiBolt guide website dedicated to `rebalance-lnd`: [https://raspibolt.org/bonus/lightning/rebalance-lnd.html](https://raspibolt.org/bonus/lightning/rebalance-lnd.html)

In case you don't know, the RaspiBolt project was created back in 2017-18 by @Stadicus and is a DIY bitcoin and lightning node manual installation guide (no OS images, no scripts, all from scratch). The core guide is kept minimal but there is a bonus section with guides on how to install and use other useful programs. We just added a rebalance-lnd guide to the Lightning section, under 'Liquidity mqnqgement': https://raspibolt.org/bonus/lightning

With this PR I propose to add a RaspiBolt entry in your `README.md`. I also added some links on the TOC at the top.. wdyt?

Also, feel free to leave some improvement suggestions for our rebalance-lnd guide.. or even make a PR if you have some thoughts on how to make it more useful.. that'd be fantastic.
